### PR TITLE
#11 - call FillTable function with correct parameters

### DIFF
--- a/site/balance.js
+++ b/site/balance.js
@@ -338,9 +338,9 @@ function GetEthPrice(tokens){
   }
 
   $.ajax(settings).done(function (response) {
-    basePrice = JSON.parse(response).ethPrice
+    basePrice = JSON.parse(response).ethPrice;
     console.log(response);
-    FillTable(tokens,JSON.parse(response).ethPrice);
+    FillTable(tokens);
   });
 }
 


### PR DESCRIPTION
Fix for https://github.com/Mshuu/mcafeedex/issues/11

basePrice is a global variable set before the function call, so it does not need to be passed to FillTable

