### PR TITLE
Header Cleanup

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -24,14 +24,13 @@
 <body class="dark">
   <div style="height: 100%">
     <div id="overlay"></div>
-  <nav class="navbar navbar-light navbar-expand-lg">
+  <header class="navbar navbar-light navbar-expand-lg">
     <div class="navBarContainer">
       <div class="LogoDiv navBarDiv">
         <a class="navbar-brand" href="/">
         </a>
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="selectMarketDiv navBarDiv" id="selectMarketDiv">
     <!--  <p class="flexP">Select Market <i class="arrow down"></i></p> -->
     </div>
@@ -40,13 +39,7 @@
             <div class="burgerMenu" onClick="HideMenu()"></div>
                   <div class="burgerMenu"></div>
                 </div>
-    <div class="lineBreak">
-    </div>
-    <div class="blankDiv navBarDiv">
-      &nbsp;
-    </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="addTokenDiv navBarDiv" id="navbarDiv">
       <!--
       React.createElement("li", {
@@ -59,25 +52,20 @@
       }, "Add Token")))
     -->
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="balancesDiv navBarDiv" id="balancesDiv">
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="whitelistDiv navBarDiv" id="whitelistdiv">
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="whitelistCheckerDiv navBarDiv">
-      <a class="flexP" href="http://whitelist.switchdex.ag/" target="_blank">Whitelist Checker</a>
+      <a class="flexP" href="http://whitelist.switchdex.ag/" target="_blank">Check Whitelist</a>
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="settingsDiv navBarDiv" id="settingsButton" style="display: none">
     </div>
-    <div class="lineBreak">
-    </div>
+
     <div class="accountDiv navBarDiv" id="accounts">
     </div>
     <!--
@@ -91,12 +79,12 @@
       </div>
     -->
   </div>
-  </nav>
+</header>
   <div class="mobileMenu" id="burgerMenuDropdown" onMouseEnter="document.getElementById('burgerMenuDropdown').style.display='flex'" onMouseLeave = "document.getElementById('burgerMenuDropdown').style.display = 'none'" style="display: none">
     <div class="mobileMenuSpan" id="navbarDiv2"></div>
     <div class="mobileMenuSpan" id="balancesDiv2"></div>
     <div class="mobileMenuSpan" id="whitelistdiv2"></div>
-     <a class="mobileMenuSpan" href="http://whitelist.switchdex.ag/" target="_blank">Whitelist Checker</a>
+    <a class="mobileMenuSpan" href="http://whitelist.switchdex.ag/" target="_blank">Check Whitelist</a>
     <div class="mobileMenuSpan" id="settingsButton2"></div>
     <div class="mobileMenuSpan" id="accounts2"><div>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -59,10 +59,6 @@
     <div class="whitelistDiv navBarDiv" id="whitelistdiv">
     </div>
 
-    <div class="whitelistCheckerDiv navBarDiv">
-      <a class="flexP" href="http://whitelist.switchdex.ag/" target="_blank">Check Whitelist</a>
-    </div>
-
     <div class="settingsDiv navBarDiv" id="settingsButton" style="display: none">
     </div>
 
@@ -84,7 +80,6 @@
     <div class="mobileMenuSpan" id="navbarDiv2"></div>
     <div class="mobileMenuSpan" id="balancesDiv2"></div>
     <div class="mobileMenuSpan" id="whitelistdiv2"></div>
-    <a class="mobileMenuSpan" href="http://whitelist.switchdex.ag/" target="_blank">Check Whitelist</a>
     <div class="mobileMenuSpan" id="settingsButton2"></div>
     <div class="mobileMenuSpan" id="accounts2"><div>
   </div>

--- a/site/main.6cfdd60c6d0446e78031.css
+++ b/site/main.6cfdd60c6d0446e78031.css
@@ -12708,6 +12708,10 @@ border-right: 1px solid var(--eleventh-color);
 margin-bottom: 0px !important;
 min-height: 3rem;
 position: relative;
+
+display: flex;
+align-items: center;
+justify-content: center;
 }
 
 .navBarDiv::last-of-type{
@@ -12909,13 +12913,9 @@ margin-bottom: 0.7rem;
 .flexP{
   font-size: 16px;
   cursor: pointer !important;
-      position: absolute;
-      left: 0;
-      bottom: 0.4rem;
       margin-bottom: 0;
       margin-left: auto;
       margin-right: auto;
-      right: 0;
       color: #e5e5e5;
       font-weight: normal;
       padding: 0;

--- a/site/main.6cfdd60c6d0446e78031.css
+++ b/site/main.6cfdd60c6d0446e78031.css
@@ -12704,9 +12704,14 @@ font-style: normal;
 font-weight: normal;
 font-size: 0.8rem !important;
 color: var(--fith-color);
+border-right: 1px solid var(--eleventh-color);
 margin-bottom: 0px !important;
 min-height: 3rem;
 position: relative;
+}
+
+.navBarDiv::last-of-type{
+    border-right: none;
 }
 .LogoDiv{
   flex:3;


### PR DESCRIPTION
These commits start to cleanup the header markup a little bit. 

Including: 

* Removing Unessecary `.linebreak` divs in header by adding borders to `.navBarDiv`s through CSS.
* Moves the "Whitelist Check" link from the header into the "Whitelist" modal. Checking the whitelist is not something everyday users are going to need, so it can be tucked away under the whitelist info. 
* Removes Absolute positioning of `.flexP` class to align menu labels to center with Flex. 