### PR TITLE
Sticky MarketPairs and SearchInput on Scrolling

### DIFF
--- a/site/main.6cfdd60c6d0446e78031.css
+++ b/site/main.6cfdd60c6d0446e78031.css
@@ -12861,6 +12861,17 @@ margin-bottom: 10px;
   float: left;
   right: none;
 }
+
+.selectMarketDropdown > li:nth-child(1){
+    position:sticky !important;
+    top:0 !important;
+}
+.selectMarketDropdown > li:nth-child(2){
+    position:sticky !important;
+    top:50px !important;
+    margin-bottom:10px !important;
+}
+
 .basePairDiv{
   display: flex;
 flex-direction: row;
@@ -14820,3 +14831,4 @@ body.light .price-y-axis path {
 body.light .price-y-axis text {
     fill: rgba(95,101,148,.4)
 }
+


### PR DESCRIPTION
Its solves #139 issue..

When user made scroll on trading pairs it will make sticky the base pairs and the search input.

![stickyscroll](https://user-images.githubusercontent.com/10724463/71695716-ff1a2e80-2dc3-11ea-81d6-d09eb3c17fef.png)
